### PR TITLE
chore: updated notes and warning colours

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -35,8 +35,8 @@ $lang-select-bg: #1E2224 !default;
 $lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #F3F7F9 !default;
-$aside-notice-bg: #8fbcd4 !default;
-$aside-warning-bg: #c97a7e !default;
+$aside-notice-bg: #ddf3ff !default;
+$aside-warning-bg: #ffe5e6 !default;
 $aside-success-bg: #6ac174 !default;
 $search-notice-bg: #c97a7e !default;
 


### PR DESCRIPTION
Updated colors for note and warning to brighter to improve readability

Before
<img width="414" alt="Screenshot 2025-06-05 at 2 31 13 PM" src="https://github.com/user-attachments/assets/d57feada-0d6c-4dcc-9fcc-2017d074d543" />
After
<img width="516" alt="Screenshot 2025-06-05 at 2 26 56 PM" src="https://github.com/user-attachments/assets/dceb8f9e-8ed8-434a-9712-7bd41a0a922d" />
